### PR TITLE
chore: send logs query param to status request as true by default

### DIFF
--- a/apps/demo-nextjs-app/pages/index.tsx
+++ b/apps/demo-nextjs-app/pages/index.tsx
@@ -71,13 +71,14 @@ export function Index() {
     setLoading(true);
     const start = Date.now();
     try {
-      const result: Result = await fal.queue.subscribe('110602490-lora', {
+      const result: Result = await fal.subscribe('110602490-lora', {
         input: {
           prompt,
           model_name: 'stabilityai/stable-diffusion-xl-base-1.0',
           image_size: 'square_hd',
         },
         pollInterval: 5000, // Default is 1000 (every 1s)
+        logs: true,
         onQueueUpdate(update) {
           setElapsedTime(Date.now() - start);
           if (

--- a/libs/client/src/function.ts
+++ b/libs/client/src/function.ts
@@ -235,7 +235,10 @@ export const queue: Queue = {
   async status(id: string, requestId: string, logs: boolean = true): Promise<QueueStatus> {
     return run(id, {
       method: 'get',
-      path: `/fal/queue/requests/${requestId}/status?logs=${logs ? '1' : '0'}`,
+      path: `/fal/queue/requests/${requestId}/status`,
+      input: {
+        logs: logs ? '1' : '0',
+      },
     });
   },
   async result<Output>(id: string, requestId: string): Promise<Output> {

--- a/libs/client/src/function.ts
+++ b/libs/client/src/function.ts
@@ -237,7 +237,7 @@ export const queue: Queue = {
   ): Promise<EnqueueResult> {
     return run(id, { ...options, method: 'post', path: '/fal/queue/submit/' });
   },
-  async status(id: string, requestId: string, logs: boolean = false): Promise<QueueStatus> {
+  async status(id: string, requestId: string, logs = false): Promise<QueueStatus> {
     return run(id, {
       method: 'get',
       path: `/fal/queue/requests/${requestId}/status`,

--- a/libs/client/src/function.ts
+++ b/libs/client/src/function.ts
@@ -131,7 +131,7 @@ export async function subscribe<Input, Output>(
     const pollInterval = options.pollInterval ?? 1000;
     const poll = async () => {
       try {
-        const requestStatus = await queue.status(id, requestId);
+        const requestStatus = await queue.status(id, requestId, true);
         if (options.onQueueUpdate) {
           options.onQueueUpdate(requestStatus);
         }
@@ -197,9 +197,10 @@ interface Queue {
    *
    * @param id - The ID or URL of the function web endpoint.
    * @param requestId - The unique identifier for the enqueued request.
+   * @param logs - If `true`, the response will include the logs for the request.
    * @returns A promise that resolves to the status of the request.
    */
-  status(id: string, requestId: string): Promise<QueueStatus>;
+  status(id: string, requestId: string, logs: boolean): Promise<QueueStatus>;
 
   /**
    * Retrieves the result of a specific request from the queue.
@@ -231,10 +232,10 @@ export const queue: Queue = {
   ): Promise<EnqueueResult> {
     return run(id, { ...options, method: 'post', path: '/fal/queue/submit/' });
   },
-  async status(id: string, requestId: string): Promise<QueueStatus> {
+  async status(id: string, requestId: string, logs: boolean = true): Promise<QueueStatus> {
     return run(id, {
       method: 'get',
-      path: `/fal/queue/requests/${requestId}/status`,
+      path: `/fal/queue/requests/${requestId}/status?logs=${logs ? '1' : '0'}`,
     });
   },
   async result<Output>(id: string, requestId: string): Promise<Output> {

--- a/libs/client/src/function.ts
+++ b/libs/client/src/function.ts
@@ -131,7 +131,7 @@ export async function subscribe<Input, Output>(
     const pollInterval = options.pollInterval ?? 1000;
     const poll = async () => {
       try {
-        const requestStatus = await queue.status(id, requestId, options.logs ?? true);
+        const requestStatus = await queue.status(id, requestId, options.logs ?? false);
         if (options.onQueueUpdate) {
           options.onQueueUpdate(requestStatus);
         }
@@ -237,7 +237,7 @@ export const queue: Queue = {
   ): Promise<EnqueueResult> {
     return run(id, { ...options, method: 'post', path: '/fal/queue/submit/' });
   },
-  async status(id: string, requestId: string, logs: boolean = true): Promise<QueueStatus> {
+  async status(id: string, requestId: string, logs: boolean = false): Promise<QueueStatus> {
     return run(id, {
       method: 'get',
       path: `/fal/queue/requests/${requestId}/status`,

--- a/libs/client/src/function.ts
+++ b/libs/client/src/function.ts
@@ -131,7 +131,7 @@ export async function subscribe<Input, Output>(
     const pollInterval = options.pollInterval ?? 1000;
     const poll = async () => {
       try {
-        const requestStatus = await queue.status(id, requestId, true);
+        const requestStatus = await queue.status(id, requestId, options.logs ?? true);
         if (options.onQueueUpdate) {
           options.onQueueUpdate(requestStatus);
         }
@@ -176,6 +176,11 @@ type QueueSubscribeOptions = {
    * @param status - The current status of the queue.
    */
   onQueueUpdate?: (status: QueueStatus) => void;
+
+  /**
+   * If `true`, the response will include the logs for the request.
+   */
+  logs?: boolean;
 };
 
 /**

--- a/libs/client/src/types.ts
+++ b/libs/client/src/types.ts
@@ -6,11 +6,6 @@ export type EnqueueResult = {
   request_id: string;
 };
 
-// export type QueueStatus = {
-//   status: "IN_PROGRESS" | "COMPLETED";
-//   queue: number;
-// };
-
 export type RequestLog = {
   message: string;
   level: 'STDERR' | 'STDOUT' | 'ERROR' | 'INFO' | 'WARN' | 'DEBUG';
@@ -22,7 +17,7 @@ export type QueueStatus =
   | {
       status: 'IN_PROGRESS' | 'COMPLETED';
       response_url: string;
-      logs: RequestLog[];
+      logs: null | RequestLog[];
     }
   | {
       status: 'IN_QUEUE';


### PR DESCRIPTION
We are making getting the logs during a status request optional. So enabling this to get them (or not) as necessary.

closes FEA-1645