### PR TITLE
feat(client): webhook url support on queue submit

### DIFF
--- a/libs/client/package.json
+++ b/libs/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fal-ai/serverless-client",
   "description": "The fal serverless JS/TS client",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/libs/client/src/index.ts
+++ b/libs/client/src/index.ts
@@ -5,4 +5,8 @@ export { withMiddleware, withProxy } from './middleware';
 export type { RequestMiddleware } from './middleware';
 export { ApiError, ValidationError } from './response';
 export type { ResponseHandler } from './response';
-export type { QueueStatus, ValidationErrorInfo } from './types';
+export type {
+  QueueStatus,
+  ValidationErrorInfo,
+  WebHookResponse,
+} from './types';

--- a/libs/client/src/types.ts
+++ b/libs/client/src/types.ts
@@ -34,3 +34,32 @@ export type ValidationErrorInfo = {
   loc: Array<string | number>;
   type: string;
 };
+
+/**
+ * Represents the response from a WebHook request.
+ * This is a union type that varies based on the `status` property.
+ *
+ * @template Payload - The type of the payload in the response. It defaults to `any`,
+ * allowing for flexibility in specifying the structure of the payload.
+ */
+export type WebHookResponse<Payload = any> =
+  | {
+      /** Indicates a successful response. */
+      status: 'OK';
+      /** The payload of the response, structure determined by the Payload type. */
+      payload: Payload;
+      /** Error is never present in a successful response. */
+      error: never;
+      /** The unique identifier for the request. */
+      request_id: string;
+    }
+  | {
+      /** Indicates an unsuccessful response. */
+      status: 'ERROR';
+      /** The payload of the response, structure determined by the Payload type. */
+      payload: Payload;
+      /** Description of the error that occurred. */
+      error: string;
+      /** The unique identifier for the request. */
+      request_id: string;
+    };


### PR DESCRIPTION
### Notes

This PR adds support to specify a `webhookUrl` to the `fal.queue.submit` API. It also adds the `WebhookResponse<Payload>` type so server-side implementations can cast the parsed response to the appropriate type.

```ts
const { request_id } = await fal.queue.submit('model-id', {
  webhookUrl: 'https://url.to/my/server/webook/handler'
});
```

On TypeScript codebases, the `WebhookResponse` type can help when webhook payloads are received:

```ts
import { WebhookResponse } from '@fal-ai/serverless-client';

// on your server you can (or something along those lines)
const result: WebhookResponse = await response.json();

if (result.status === 'OK') {
  // result.error is not available
}
```