### PR TITLE
fix: don't crash inside cloudflare workers

### DIFF
--- a/libs/client/src/request.ts
+++ b/libs/client/src/request.ts
@@ -1,6 +1,10 @@
 import { getConfig } from './config';
 import { getUserAgent, isBrowser } from './runtime';
 
+const isCloudflareWorkers =
+  typeof navigator !== 'undefined' &&
+  navigator?.userAgent === 'Cloudflare-Workers';
+
 export async function dispatchRequest<Input, Output>(
   method: string,
   targetUrl: string,
@@ -37,7 +41,7 @@ export async function dispatchRequest<Input, Output>(
   const response = await fetch(url, {
     method,
     headers: requestHeaders,
-    mode: 'cors',
+    ...(!isCloudflareWorkers && { mode: 'cors' }),
     body:
       method.toLowerCase() !== 'get' && input
         ? JSON.stringify(input)


### PR DESCRIPTION
I noticed an error when trying to use the client from inside Cloudflare Workers/PartyKit. Specifically, this request fails https://github.com/fal-ai/serverless-js/blob/6ad41e1bfa5d0ee6e99d4d39f80a6c07a866f5ff/libs/client/src/request.ts#L40
 because Cloudflare Workers doesn't support the `mode` field on `fetch()` calls. (More info https://github.com/cloudflare/workers-sdk/issues/4159)

The fix here is to detect `navigator.userAgent === 'Cloudflare-Workers'` and add the `mode` field only when that condition is false. 

Hope this helps!